### PR TITLE
fix for Marlin/issues/23926

### DIFF
--- a/Marlin/src/pins/ramps/pins_MKS_GEN_L.h
+++ b/Marlin/src/pins/ramps/pins_MKS_GEN_L.h
@@ -37,6 +37,12 @@
 // Power outputs EFBF or EFBE
 #define MOSFET_D_PIN 7
 
+// Hotend, Hotend, Bed + Fan on D9
+#if FET_ORDER_EEB
+  #define MOSFET_B_PIN 7
+  #define FAN_PIN 9
+#endif
+
 //
 // CS Pins wired to avoid conflict with the LCD
 // See https://www.thingiverse.com/asset:66604


### PR DESCRIPTION
### Requirements

Proposed fix for this issue:
https://github.com/MarlinFirmware/Marlin/issues/23926

### Description

just repeting what I wrote in that issue:

when using in Configuration.h (attached below):

#define MOTHERBOARD BOARD_MKS_GEN_L
#define EXTRUDERS 2

it uses pins_MKS_GEN_L.h, which in turn uses pins_RAMPS.h,
where FET_ORDER_EEB is selected (which is right), but pins in RAMPS and MKS GEN L don't match in second extruder:

#elif FET_ORDER_EEB // Hotend, Hotend, Bed
#define HEATER_1_PIN MOSFET_B_PIN
#define HEATER_BED_PIN MOSFET_C_PIN

#elif FET_ORDER_EEB // Hotend, Hotend, Bed
#define FAN_PIN 4 // IO pin. Buffer needed

(from pins_RAMPS.h)

this leads to:
HEATER_1_PIN = 9
FAN_PIN = 4

actual MKS GEN L pins map:
https://github.com/makerbase-mks/MKS-GEN_L/blob/master/hardware/MKS%20Gen_L%20V1.0_008/MKS%20Gen_L%20V1.0_008%20PIN.pdf

pin D9 is fan pin and D4 is servo pin, so when enabling second extruder heater, fan turns ON and there is no way to power on fan.
(also I wouldn't power up extruder heater from fan socket, it very possibly might no handle 40W output)

adding this into pins_MKS_GEN_L.h (from line 40) fixes this issue:

// Hotend, Hotend, Bed + Fan on D9
#if FET_ORDER_EEB
#define MOSFET_B_PIN 7
#define FAN_PIN 9
#endif


### Benefits

it sets proper pins for second extruder and fan when using two heaters, bed and fan

### Configurations
[Configuration.zip](https://github.com/aegelsky/Marlin/files/8373840/Configuration.zip)



### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/23926
